### PR TITLE
chore: bump vcl react native version to 2.9.0

### DIFF
--- a/VclReactNative.podspec
+++ b/VclReactNative.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
-  s.dependency "VCL", "2.8.2"
+  s.dependency "VCL", "2.9.0"
 
   install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
 //--------- Must: be added:
-  implementation "io.velocitycareerlabs:vcl:2.8.2"
+  implementation "io.velocitycareerlabs:vcl:2.9.0"
   implementation 'com.nimbusds:nimbus-jose-jwt:10.5'
   implementation "androidx.security:security-crypto:1.1.0"
 //-------------------------

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2254,8 +2254,8 @@ PODS:
     - React-utils (= 0.81.4)
     - SocketRocket
   - SocketRocket (0.7.1)
-  - VCL (2.8.2)
-  - VclReactNative (2.8.2):
+  - VCL (2.9.0)
+  - VclReactNative (2.9.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2282,7 +2282,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VCL (= 2.8.2)
+    - VCL (= 2.9.0)
     - Yoga
   - Yoga (0.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velocitycareerlabs/vcl-react-native",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- bump the package version to 2.9.0
- point the iOS and Android native dependencies at VCL 2.9.0
- update the example iOS lockfile to match

## Verification
- yarn install
- yarn lint
- yarn typecheck

## Note
- this should merge after WalletIOS and WalletAndroid 2.9.0 are published, since the published React Native package will require native VCL 2.9.0 artifacts