### PR TITLE
chore: bump native sdk dependencies to 2.9.0

### DIFF
--- a/VclReactNative.podspec
+++ b/VclReactNative.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
-  s.dependency "VCL", "2.8.2"
+  s.dependency "VCL", "2.9.0"
 
   install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
 //--------- Must: be added:
-  implementation "io.velocitycareerlabs:vcl:2.8.2"
+  implementation "io.velocitycareerlabs:vcl:2.9.0"
   implementation 'com.nimbusds:nimbus-jose-jwt:10.5'
   implementation "androidx.security:security-crypto:1.1.0"
 //-------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velocitycareerlabs/vcl-react-native",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- bump `@velocitycareerlabs/vcl-react-native` to `2.9.0`
- update the iOS pod dependency to `VCL 2.9.0`
- update the Android Maven dependency to `io.velocitycareerlabs:vcl:2.9.0`

## Verification
- `yarn lint`
- `yarn typecheck`
- `yarn test --runInBand --watchman=false`