### PR TITLE
ci: migrate npm publishing to trusted publishing

### DIFF
--- a/.github/workflows/react-native-sdk.workflow.yml
+++ b/.github/workflows/react-native-sdk.workflow.yml
@@ -14,7 +14,12 @@ on:
         options:
           - dev
           - rc
-          - prod
+      - prod
+
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
@@ -33,23 +38,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      # Publish to npm
-      - name: Set NPM Packages Config
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-      # Git Set Identity
-      - name: Git Identity
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-      # Commit Version Locally for Github npm
-      - name: Commit Version Locally for Github npm
-        run: git add .npmrc && git commit -am "Prepare to release"
+          registry-url: 'https://registry.npmjs.org'
       # Install dependencies
       - name: Install dependencies
         run: corepack enable && yarn set version 3.6.1 && yarn install --frozen-lockfile
       # Build and Publish SDK
       - name: Build and Publish SDK
         if: ${{ env.GLOBAL_ENV == 'prod' || env.GLOBAL_ENV == 'rc' }}
-        run: npm publish --tag ${{ env.RELEASE_TAG }} --access public --userconfig ./.npmrc
+        run: npm publish --tag ${{ env.RELEASE_TAG }} --access public
         env:
           RELEASE_TAG: ${{ env.GLOBAL_ENV == 'prod' && format('{0}', 'latest' ) || env.RC_SUFFIX }}

--- a/.github/workflows/react-native-sdk.workflow.yml
+++ b/.github/workflows/react-native-sdk.workflow.yml
@@ -14,7 +14,7 @@ on:
         options:
           - dev
           - rc
-      - prod
+          - prod
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
- migrate npm publishing from token-based auth to GitHub trusted publishing
- add the workflow permissions required for npm OIDC
- remove the temporary `.npmrc` and local commit step from the release workflow

## Notes
- npm package settings still need to trust this GitHub repository as a publisher

## Verification
- workflow change only; not run locally