### PR TITLE
chore: release 2.9.1

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2255,7 +2255,7 @@ PODS:
     - SocketRocket
   - SocketRocket (0.7.1)
   - VCL (2.9.3)
-  - VclReactNative (2.9.0):
+  - VclReactNative (2.9.1):
     - boost
     - DoubleConversion
     - fast_float

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velocitycareerlabs/vcl-react-native",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- bump the React Native package version to 2.9.1
- refresh the local example iOS pod lock entry to the new package version

## Notes
- main already contains the merged native error handling and diagnostics bridge work
- this PR is the release bump only