### PR TITLE
fix(ci): add GitHub workflow linting

### DIFF
--- a/.github/workflows/github-workflow-linting.workflow.yml
+++ b/.github/workflows/github-workflow-linting.workflow.yml
@@ -1,0 +1,21 @@
+name: GitHub Workflow Linting
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/**'
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color


### PR DESCRIPTION
## Summary
- add actionlint CI for GitHub workflow changes
- run actionlint through the pinned rhysd/actionlint:1.7.12 Docker image
- enable ShellCheck as part of actionlint

## Validation
- docker run --rm -v /Users/andresolave/Projects/velocity/vcl-react-native-codex-actionlint-ci:/repo -w /repo rhysd/actionlint:1.7.12 -color