### PR TITLE
[codex] update SDK to 2.10.0-rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ npm install @velocitycareerlabs/vcl-react-native --save
 ### Usage
 To start using the VCL SDK, you’ll need to create its object and initialize it in Velocity Network&trade;:
 ```js
-import vcl from '@velocitycareerlabs/vcl-react-native';
+import vcl, {
+  VCLErrorCodeCompatibilityMode,
+} from '@velocitycareerlabs/vcl-react-native';
 ```
 ```js
 const initializationDescriptor: VCLInitializationDescriptor = {
@@ -62,6 +64,15 @@ vcl.initialize(initializationDescriptor).then(
     // Handle initialization failure
   }
 );
+```
+
+SDK `2.10.0-rc` uses native taxonomy error codes by default. To temporarily
+preserve legacy native error-code mappings during migration, initialize with:
+```js
+const initializationDescriptor: VCLInitializationDescriptor = {
+  environment: environment,
+  errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode.Legacy,
+};
 ```
 
 More details can be found [HERE](https://www.velocitynetwork.foundation/main/career-wallets-velocity-sdks#react-native)

--- a/VclReactNative.podspec
+++ b/VclReactNative.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
-  s.dependency "VCL", "2.9.3"
+  s.dependency "VCL", "2.10.0-rc"
 
   install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
 //--------- Must: be added:
-  implementation "io.velocitycareerlabs:vcl:2.9.2"
+  implementation "io.velocitycareerlabs:vcl:2.10.0-rc"
   implementation 'com.nimbusds:nimbus-jose-jwt:10.5'
   implementation "androidx.security:security-crypto:1.1.0"
 //-------------------------

--- a/android/src/main/java/io/velocitycareerlabs/reactnative/utlis/Converter.kt
+++ b/android/src/main/java/io/velocitycareerlabs/reactnative/utlis/Converter.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.*
 import io.velocitycareerlabs.api.*
 import io.velocitycareerlabs.api.entities.*
 import io.velocitycareerlabs.api.entities.initialization.VCLCryptoServicesDescriptor
+import io.velocitycareerlabs.api.entities.initialization.VCLErrorCodeCompatibilityMode
 import io.velocitycareerlabs.api.entities.initialization.VCLInitializationDescriptor
 import io.velocitycareerlabs.api.entities.initialization.VCLJwtServiceUrls
 import io.velocitycareerlabs.api.entities.initialization.VCLKeyServiceUrls
@@ -34,7 +35,10 @@ object Converter {
       initializationDescriptorMap.getMapOpt("cryptoServicesDescriptor")
     ),
     isDirectIssuerCheckOn = initializationDescriptorMap.getBooleanOpt("isDirectIssuerCheckOn")
-      ?: true
+      ?: true,
+    errorCodeCompatibilityMode = mapToErrorCodeCompatibilityMode(
+      initializationDescriptorMap.getStringOpt("errorCodeCompatibilityMode")
+    )
   )
 
   private fun mapToEnvironment(environment: String?) =
@@ -68,6 +72,11 @@ object Converter {
 
   private fun mapToXVnfProtocolVersion(xVnfProtocolVersion: String?) =
     VCLXVnfProtocolVersion.fromString(xVnfProtocolVersion ?: "")
+
+  private fun mapToErrorCodeCompatibilityMode(errorCodeCompatibilityMode: String?) =
+    VCLErrorCodeCompatibilityMode.entries.firstOrNull {
+      it.value == errorCodeCompatibilityMode
+    } ?: VCLErrorCodeCompatibilityMode.Taxonomy
 
   fun regionToMap(
     region: VCLRegion
@@ -796,4 +805,3 @@ object Converter {
     )
   }
 }
-

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2255,7 +2255,7 @@ PODS:
     - SocketRocket
   - SocketRocket (0.7.1)
   - VCL (2.9.3)
-  - VclReactNative (2.9.0):
+  - VclReactNative (2.9.1):
     - boost
     - DoubleConversion
     - fast_float

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2254,8 +2254,8 @@ PODS:
     - React-utils (= 0.81.4)
     - SocketRocket
   - SocketRocket (0.7.1)
-  - VCL (2.9.3)
-  - VclReactNative (2.9.1):
+  - VCL (2.10.0-rc)
+  - VclReactNative (2.10.0-rc):
     - boost
     - DoubleConversion
     - fast_float
@@ -2282,7 +2282,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VCL (= 2.9.3)
+    - VCL (= 2.10.0-rc)
     - Yoga
   - Yoga (0.0.0)
 
@@ -2587,8 +2587,8 @@ SPEC CHECKSUMS:
   ReactCodegen: 1d05923ad119796be9db37830d5e5dc76586aa00
   ReactCommon: 394c6b92765cf6d211c2c3f7f6bc601dffb316a6
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VCL: ddd97baeeb55c836bc9d62a2d0c1aa67ea8dad70
-  VclReactNative: f799e8ba16febf859d7d5912b2d472e4bca034a6
+  VCL: 59cba151f3499e8c03c63ad157927cd1ac0d19bc
+  VclReactNative: aa86a8de3b4b9147dcf9911e8665dff2a86d81ea
   Yoga: a3ed390a19db0459bd6839823a6ac6d9c6db198d
 
 PODFILE CHECKSUM: c716dbb5c708f8f12edc61c121a3a6625e50177a

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -29,6 +29,7 @@ import vcl, {
   type VCLDeepLink,
   type VCLDidJwk,
   type VCLDidJwkDescriptor,
+  VCLErrorCodeCompatibilityMode,
   VCLEnvironment,
   type VCLError,
   type VCLExchange,
@@ -96,6 +97,7 @@ export default () => {
     const initialize = async () => {
       const initializationDescriptor: VCLInitializationDescriptor = {
         environment,
+        errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode.Taxonomy,
         nativeErrorStackFrameLimit: 20,
       };
 

--- a/ios/Utils/Converter.swift
+++ b/ios/Utils/Converter.swift
@@ -26,7 +26,10 @@ func dictionaryToInitializationDescriptor(
     cryptoServicesDescriptor: dictionaryToCryptoServicesDescriptor(
       initializationDescriptorDictionary["cryptoServicesDescriptor"] as? [String : Any]
     ),
-    isDirectIssuerCheckOn: initializationDescriptorDictionary["isDirectIssuerCheckOn"] as? Bool ?? true
+    isDirectIssuerCheckOn: initializationDescriptorDictionary["isDirectIssuerCheckOn"] as? Bool ?? true,
+    errorCodeCompatibilityMode: dictionaryToErrorCodeCompatibilityMode(
+      initializationDescriptorDictionary["errorCodeCompatibilityMode"] as? String
+    )
   )
 }
 
@@ -65,6 +68,14 @@ private func dictionaryToXVnfProtocolVersion(
     _ xVnfProtocolVersion: String?
 ) -> VCLXVnfProtocolVersion {
   return VCLXVnfProtocolVersion.fromString(value: xVnfProtocolVersion ?? "")
+}
+
+private func dictionaryToErrorCodeCompatibilityMode(
+  _ errorCodeCompatibilityMode: String?
+) -> VCLErrorCodeCompatibilityMode {
+  return VCLErrorCodeCompatibilityMode(
+    rawValue: errorCodeCompatibilityMode ?? ""
+  ) ?? .Taxonomy
 }
 
 func regionToDictionary(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velocitycareerlabs/vcl-react-native",
-  "version": "2.9.1",
+  "version": "2.10.0-rc",
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velocitycareerlabs/vcl-react-native",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,8 +1,10 @@
 import { VCLError } from '../api/entities/error/VCLError';
+import { VCLErrorCode } from '../api/entities/error/VCLErrorCode';
 import {
   BRIDGED_VCL_ERROR_CODE,
   VCLErrorDeserializer,
 } from '../api/entities/error/VCLErrorDeserializer';
+import { VCLErrorCodeCompatibilityMode } from '../api/entities/initialization/VCLErrorCodeCompatibilityMode';
 
 describe('VCLError', () => {
   it('keeps the constructor as a plain structured initializer', () => {
@@ -84,5 +86,22 @@ describe('VCLError', () => {
 
   it('exports the bridge marker constant', () => {
     expect(BRIDGED_VCL_ERROR_CODE).toBe('VCL_BRIDGED_ERROR_V1');
+  });
+
+  it('exposes native error taxonomy codes', () => {
+    expect(VCLErrorCode.InvalidLink).toBe('invalid_link');
+    expect(VCLErrorCode.ConnectivityFailure).toBe('connectivity_failure');
+    expect(VCLErrorCode.RegistrationCheckInconclusive).toBe(
+      'registration_check_inconclusive'
+    );
+    expect(VCLErrorCode.IssuerRequestInvalid).toBe('issuer_request_invalid');
+    expect(VCLErrorCode.VerifierRequestUnauthorized).toBe(
+      'verifier_request_unauthorized'
+    );
+  });
+
+  it('exposes native error code compatibility modes', () => {
+    expect(VCLErrorCodeCompatibilityMode.Taxonomy).toBe('taxonomy');
+    expect(VCLErrorCodeCompatibilityMode.Legacy).toBe('legacy');
   });
 });

--- a/src/api/entities/error/VCLErrorCode.ts
+++ b/src/api/entities/error/VCLErrorCode.ts
@@ -6,6 +6,10 @@
  */
 
 export enum VCLErrorCode {
+  // Initialization
+  RemoteServicesUrlsNotFount = 'remote_services_urls_not_found',
+  InjectedServicesNotFount = 'injected_services_not_found',
+
   // Credential issuer verification error codes:
   CredentialTypeNotRegistered = 'credential_type_not_registered',
   IssuerRequiresIdentityPermission = 'issuer_requires_identity_permission',
@@ -19,6 +23,20 @@ export enum VCLErrorCode {
   MismatchedOfferIssuerDid = 'mismatched_offer_issuer_did',
   MismatchedCredentialIssuerDid = 'mismatched_credential_issuer_did',
   MismatchedPresentationRequestInspectorDid = 'mismatched_presentation_request_inspector_did',
+  // Error taxonomy
+  InvalidLink = 'invalid_link',
+  ConnectivityFailure = 'connectivity_failure',
+  ClientRequestUnauthorized = 'client_request_unauthorized',
+  ClientRequestRejected = 'client_request_rejected',
+  IssuerDidUnresolvable = 'issuer_did_unresolvable',
+  VerifierDidUnresolvable = 'verifier_did_unresolvable',
+  RegistrationCheckInconclusive = 'registration_check_inconclusive',
+  IssuerNotRegistered = 'issuer_not_registered',
+  VerifierNotRegistered = 'verifier_not_registered',
+  IssuerRequestInvalid = 'issuer_request_invalid',
+  VerifierRequestInvalid = 'verifier_request_invalid',
+  IssuerRequestUnauthorized = 'issuer_request_unauthorized',
+  VerifierRequestUnauthorized = 'verifier_request_unauthorized',
   // General error
   SdkError = 'sdk_error',
 }

--- a/src/api/entities/error/VCLErrorCode.ts
+++ b/src/api/entities/error/VCLErrorCode.ts
@@ -7,8 +7,8 @@
 
 export enum VCLErrorCode {
   // Initialization
-  RemoteServicesUrlsNotFount = 'remote_services_urls_not_found',
-  InjectedServicesNotFount = 'injected_services_not_found',
+  RemoteServicesUrlsNotFound = 'remote_services_urls_not_found',
+  InjectedServicesNotFound = 'injected_services_not_found',
 
   // Credential issuer verification error codes:
   CredentialTypeNotRegistered = 'credential_type_not_registered',

--- a/src/api/entities/initialization/VCLErrorCodeCompatibilityMode.ts
+++ b/src/api/entities/initialization/VCLErrorCodeCompatibilityMode.ts
@@ -1,0 +1,11 @@
+/**
+ * Created by Michael Avoyan.
+ *
+ * Copyright 2022 Velocity Career Labs inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export enum VCLErrorCodeCompatibilityMode {
+  Taxonomy = 'taxonomy',
+  Legacy = 'legacy',
+}

--- a/src/api/entities/initialization/VCLInitializationDescriptor.ts
+++ b/src/api/entities/initialization/VCLInitializationDescriptor.ts
@@ -7,6 +7,7 @@
 
 import type { VCLEnvironment } from '../../VCLEnvironment';
 import type { VCLCryptoServicesDescriptor } from './VCLCryptoServicesDescriptor';
+import type { VCLErrorCodeCompatibilityMode } from './VCLErrorCodeCompatibilityMode';
 import type { VCLXVnfProtocolVersion } from '../../VCLXVnfProtocolVersion';
 
 export interface VCLInitializationDescriptor {
@@ -16,6 +17,11 @@ export interface VCLInitializationDescriptor {
   isDebugOn?: boolean;
   cryptoServicesDescriptor?: VCLCryptoServicesDescriptor;
   isDirectIssuerCheckOn?: boolean;
+  /**
+   * Controls whether native SDK errors use the new taxonomy codes or legacy
+   * backward-compatible mappings. Native SDKs default to taxonomy mode.
+   */
+  errorCodeCompatibilityMode?: VCLErrorCodeCompatibilityMode;
   /**
    * Maximum number of native stack frames to include in bridged error diagnostics.
    * Native implementations clamp values to the range `0..20`.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import { VCLEnvironment } from './api/VCLEnvironment';
 import { VCLXVnfProtocolVersion } from './api/VCLXVnfProtocolVersion';
 import { VCLCryptoServiceType } from './api/VCLCryptoServiceType';
 import { VCLSignatureAlgorithm } from './api/VCLSignatureAlgorithm';
+import { VCLErrorCodeCompatibilityMode } from './api/entities/initialization/VCLErrorCodeCompatibilityMode';
 import type { VCLCryptoServicesDescriptor } from './api/entities/initialization/VCLCryptoServicesDescriptor';
 import type { VCLJwtServiceUrls } from './api/entities/initialization/VCLJwtServiceUrls';
 import type { VCLKeyServiceUrls } from './api/entities/initialization/VCLKeyServiceUrls';
@@ -86,6 +87,7 @@ export {
   VCLError,
   VCLStatusCode,
   VCLErrorCode,
+  VCLErrorCodeCompatibilityMode,
 };
 export type {
   Dictionary,


### PR DESCRIPTION
## Summary

- Update the React Native package and native SDK pins to 2.10.0-rc.
- Expose the native error taxonomy codes and error-code compatibility mode in the TypeScript API.
- Bridge `errorCodeCompatibilityMode` through Android and iOS initialization, and document the taxonomy default plus legacy migration mode.

## Validation

- `yarn typecheck`
- `yarn test --runInBand`
- `yarn lint`
- `yarn prepare`
- `git diff --check`
- `./gradlew :velocitycareerlabs_vcl-react-native:compileDebugKotlin --no-daemon --console=plain`

## Notes

- `bundle exec pod update VCL --repo-update` currently fails because configured CocoaPods spec sources do not contain `VCL (= 2.10.0-rc)` yet; the Velocity specs repo still resolves latest `VCL` as `2.9.3`.
