### PR TITLE
[codex] decouple wrapper and native SDK versions

### DIFF
--- a/.github/workflows/react-native-sdk.workflow.yml
+++ b/.github/workflows/react-native-sdk.workflow.yml
@@ -15,6 +15,9 @@ on:
           - dev
           - rc
           - prod
+      rcIndex:
+        description: Optional release candidate index. Defaults to the CI run number.
+        required: false
 
 permissions:
   id-token: write
@@ -42,6 +45,13 @@ jobs:
       # Install dependencies
       - name: Install dependencies
         run: corepack enable && yarn set version 3.6.1 && yarn install --frozen-lockfile
+      # Apply CI package version
+      - name: Apply release candidate version
+        if: ${{ env.GLOBAL_ENV == 'rc' }}
+        run: node scripts/apply-ci-version.js
+        env:
+          RC_INDEX: ${{ github.event.inputs.rcIndex }}
+          RC_SUFFIX: ${{ env.RC_SUFFIX }}
       # Build and Publish SDK
       - name: Build and Publish SDK
         if: ${{ env.GLOBAL_ENV == 'prod' || env.GLOBAL_ENV == 'rc' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,10 @@ To publish new versions, run the following:
 yarn release
 ```
 
+For release candidate publishes, dispatch the `ReactNative-SDK-Publish`
+workflow with the `rc` environment. CI appends a SemVer `rc.<index>` suffix to
+the target patch version in `package.json` before publishing.
+
 ### Scripts
 
 The `package.json` file contains various scripts for common tasks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,11 @@ For release candidate publishes, dispatch the `ReactNative-SDK-Publish`
 workflow with the `rc` environment. CI appends a SemVer `rc.<index>` suffix to
 the target patch version in `package.json` before publishing.
 
+The wrapper package version and native SDK artifact versions do not need to
+match. For wrapper-only releases, leave `vclNativeSdkVersions` pinned to the
+published iOS and Android native SDK artifact versions. Update those pins only
+when the corresponding native SDK artifacts are published.
+
 ### Scripts
 
 The `package.json` file contains various scripts for common tasks:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ vcl.initialize(initializationDescriptor).then(
 );
 ```
 
-SDK `2.10.0-rc` uses native taxonomy error codes by default. To temporarily
+SDK `2.10.0` uses native taxonomy error codes by default. To temporarily
 preserve legacy native error-code mappings during migration, initialize with:
 ```js
 const initializationDescriptor: VCLInitializationDescriptor = {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ yarn add @velocitycareerlabs/vcl-react-native
 npm install @velocitycareerlabs/vcl-react-native --save
 ```
 
+### Native SDK versions
+By default, the package pins native iOS and Android SDK versions through
+`vclNativeSdkVersions` in its `package.json`, falling back to the React Native
+package version if no native pin is present.
+
+```json
+{
+  "version": "2.10.0",
+  "vclNativeSdkVersions": {
+    "ios": "2.10.0-rc",
+    "android": "2.10.0-rc"
+  }
+}
+```
+
 ### Usage
 To start using the VCL SDK, you’ll need to create its object and initialize it in Velocity Network&trade;:
 ```js

--- a/VclReactNative.podspec
+++ b/VclReactNative.podspec
@@ -2,6 +2,13 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
+def first_present_value(*values)
+  values.find { |value| !value.nil? && !value.to_s.strip.empty? }
+end
+
+vcl_native_sdk_versions = package["vclNativeSdkVersions"] || {}
+vcl_ios_sdk_version = first_present_value(vcl_native_sdk_versions["ios"], package["version"])
+
 Pod::Spec.new do |s|
   s.name         = "VclReactNative"
   s.version      = package["version"]
@@ -18,7 +25,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
-  s.dependency "VCL", package["version"]
+  s.dependency "VCL", vcl_ios_sdk_version
 
   install_modules_dependencies(s)
 end

--- a/VclReactNative.podspec
+++ b/VclReactNative.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
-  s.dependency "VCL", "2.10.0-rc"
+  s.dependency "VCL", package["version"]
 
   install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,9 @@ apply plugin: "kotlin-android"
 
 apply plugin: "com.facebook.react"
 
+def packageJson = new groovy.json.JsonSlurper().parse(file("$projectDir/../package.json"))
+def vclSdkVersion = packageJson.version
+
 def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["VclReactNative_" + name]).toInteger()
 }
@@ -76,7 +79,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
 //--------- Must: be added:
-  implementation "io.velocitycareerlabs:vcl:2.10.0-rc"
+  implementation "io.velocitycareerlabs:vcl:$vclSdkVersion"
   implementation 'com.nimbusds:nimbus-jose-jwt:10.5'
   implementation "androidx.security:security-crypto:1.1.0"
 //-------------------------

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,14 @@ apply plugin: "kotlin-android"
 apply plugin: "com.facebook.react"
 
 def packageJson = new groovy.json.JsonSlurper().parse(file("$projectDir/../package.json"))
-def vclSdkVersion = packageJson.version
+def vclNativeSdkVersions = packageJson.vclNativeSdkVersions instanceof Map ? packageJson.vclNativeSdkVersions : [:]
+def firstPresentValue = { values ->
+  return values.find { value -> value != null && value.toString().trim() }
+}
+def vclSdkVersion = firstPresentValue([
+  vclNativeSdkVersions.android,
+  packageJson.version,
+])
 
 def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["VclReactNative_" + name]).toInteger()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velocitycareerlabs/vcl-react-native",
-  "version": "2.10.0-rc",
+  "version": "2.10.0",
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@velocitycareerlabs/vcl-react-native",
   "version": "2.10.0",
+  "vclNativeSdkVersions": {
+    "ios": "2.10.0-rc",
+    "android": "2.10.0-rc"
+  },
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/scripts/__tests__/apply-ci-version.test.js
+++ b/scripts/__tests__/apply-ci-version.test.js
@@ -5,12 +5,16 @@ const { spawnSync } = require('node:child_process');
 
 const scriptPath = path.join(__dirname, '..', 'apply-ci-version.js');
 
-const writePackageJson = (version) => {
+const writePackageJson = (version, overrides = {}) => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vcl-ci-version-'));
   const packageJsonPath = path.join(tmpDir, 'package.json');
   fs.writeFileSync(
     packageJsonPath,
-    `${JSON.stringify({ name: 'test-package', version }, null, 2)}\n`
+    `${JSON.stringify(
+      { name: 'test-package', version, ...overrides },
+      null,
+      2
+    )}\n`
   );
   return packageJsonPath;
 };
@@ -54,6 +58,29 @@ describe('apply-ci-version', () => {
     expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version).toBe(
       '2.10.0-rc.42'
     );
+  });
+
+  it('leaves native SDK version pins unchanged', () => {
+    const packageJsonPath = writePackageJson('2.10.0', {
+      vclNativeSdkVersions: {
+        ios: '2.9.0',
+        android: '2.9.0',
+      },
+    });
+
+    const result = runScript(packageJsonPath, {
+      RC_INDEX: '7',
+      RC_SUFFIX: 'rc',
+    });
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    expect(result.status).toBe(0);
+    expect(packageJson.version).toBe('2.10.0-rc.7');
+    expect(packageJson.vclNativeSdkVersions).toEqual({
+      ios: '2.9.0',
+      android: '2.9.0',
+    });
   });
 
   it('rejects invalid release candidate indexes', () => {

--- a/scripts/__tests__/apply-ci-version.test.js
+++ b/scripts/__tests__/apply-ci-version.test.js
@@ -1,0 +1,88 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const scriptPath = path.join(__dirname, '..', 'apply-ci-version.js');
+
+const writePackageJson = (version) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vcl-ci-version-'));
+  const packageJsonPath = path.join(tmpDir, 'package.json');
+  fs.writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify({ name: 'test-package', version }, null, 2)}\n`
+  );
+  return packageJsonPath;
+};
+
+const runScript = (packageJsonPath, env) =>
+  spawnSync(process.execPath, [scriptPath], {
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: '',
+      PACKAGE_JSON_PATH: packageJsonPath,
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+
+describe('apply-ci-version', () => {
+  it('adds the CI release candidate index to the package version', () => {
+    const packageJsonPath = writePackageJson('2.10.0');
+
+    const result = runScript(packageJsonPath, {
+      RC_INDEX: '7',
+      RC_SUFFIX: 'rc',
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version).toBe(
+      '2.10.0-rc.7'
+    );
+  });
+
+  it('uses the GitHub run number when no explicit index is provided', () => {
+    const packageJsonPath = writePackageJson('2.10.0');
+
+    const result = runScript(packageJsonPath, {
+      RC_INDEX: '',
+      GITHUB_RUN_NUMBER: '42',
+      RC_SUFFIX: 'rc',
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version).toBe(
+      '2.10.0-rc.42'
+    );
+  });
+
+  it('rejects invalid release candidate indexes', () => {
+    const packageJsonPath = writePackageJson('2.10.0');
+
+    const result = runScript(packageJsonPath, {
+      RC_INDEX: '01',
+      RC_SUFFIX: 'rc',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Invalid RC index');
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version).toBe(
+      '2.10.0'
+    );
+  });
+
+  it('rejects prerelease package versions', () => {
+    const packageJsonPath = writePackageJson('2.10.0-rc');
+
+    const result = runScript(packageJsonPath, {
+      RC_INDEX: '1',
+      RC_SUFFIX: 'rc',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('target patch version');
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version).toBe(
+      '2.10.0-rc'
+    );
+  });
+});

--- a/scripts/apply-ci-version.js
+++ b/scripts/apply-ci-version.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const packageJsonPath =
+  process.env.PACKAGE_JSON_PATH ?? path.join(__dirname, '..', 'package.json');
+const rcSuffix = process.env.RC_SUFFIX ?? 'rc';
+const rcIndex = process.env.RC_INDEX || process.env.GITHUB_RUN_NUMBER;
+
+const semverIdentifierRegex = /^[0-9A-Za-z-]+$/;
+const numericIdentifierRegex = /^(0|[1-9]\d*)$/;
+
+const fail = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+
+if (!semverIdentifierRegex.test(rcSuffix)) {
+  fail(`Invalid RC_SUFFIX "${rcSuffix}". Expected a SemVer identifier.`);
+}
+
+if (!rcIndex || !numericIdentifierRegex.test(rcIndex)) {
+  fail(
+    `Invalid RC index "${rcIndex ?? ''}". Set RC_INDEX or GITHUB_RUN_NUMBER to a non-negative integer.`
+  );
+}
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const currentVersion = packageJson.version;
+const stableVersionRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+const match = currentVersion.match(stableVersionRegex);
+
+if (!match) {
+  fail(
+    `Package version "${currentVersion}" must be a target patch version before CI can append ${rcSuffix}.<index>.`
+  );
+}
+
+const [, major, minor, patch] = match;
+const nextVersion = `${major}.${minor}.${patch}-${rcSuffix}.${rcIndex}`;
+packageJson.version = nextVersion;
+
+fs.writeFileSync(
+  packageJsonPath,
+  `${JSON.stringify(packageJson, null, 2)}\n`,
+  'utf8'
+);
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${nextVersion}\n`);
+}
+
+console.info(`Applied CI package version ${nextVersion}`);


### PR DESCRIPTION
## Summary
- add CI support for publishing indexed React Native wrapper RC versions from a stable target version
- add `vclNativeSdkVersions` package metadata so iOS and Android native SDK artifact versions can be pinned independently from the wrapper version
- make the iOS podspec and Android Gradle dependency read those file-based native pins, falling back to `package.json` `version` when a platform pin is absent
- document the native version pins and release workflow guidance

## Why
The React Native wrapper version does not always match the native iOS and Android SDK artifact versions. Wrapper-only RC publishes should not require matching native artifacts to exist.

## Validation
- `ruby -c VclReactNative.podspec`
- `yarn test scripts/__tests__/apply-ci-version.test.js`
- `yarn lint`
- `./gradlew :velocitycareerlabs_vcl-react-native:dependencyInsight --configuration debugRuntimeClasspath --dependency io.velocitycareerlabs:vcl`
