### PR TITLE
[codex] fix iOS podspec native SDK lookup

### DIFF
--- a/VclReactNative.podspec
+++ b/VclReactNative.podspec
@@ -2,12 +2,11 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-def first_present_value(*values)
-  values.find { |value| !value.nil? && !value.to_s.strip.empty? }
-end
-
 vcl_native_sdk_versions = package["vclNativeSdkVersions"] || {}
-vcl_ios_sdk_version = first_present_value(vcl_native_sdk_versions["ios"], package["version"])
+vcl_ios_sdk_version = [
+  vcl_native_sdk_versions["ios"],
+  package["version"]
+].find { |value| !value.nil? && !value.to_s.strip.empty? }
 
 Pod::Spec.new do |s|
   s.name         = "VclReactNative"


### PR DESCRIPTION
## Summary
- remove the top-level `first_present_value` helper from `VclReactNative.podspec`
- inline the native iOS SDK version lookup so CocoaPods can evaluate the podspec
- keep the existing behavior: `vclNativeSdkVersions.ios` falls back to `package.json` `version`

## Why
`vcl-react-native@2.10.0-rc.2` decoupled wrapper and native SDK versions, but the podspec helper method is evaluated in a CocoaPods context where `first_present_value` is not available. That makes holderapp fail during iOS pod installation before it can delete its patch.

## Validation
- `ruby -c VclReactNative.podspec`
- `bundle exec pod install` from `example/ios` completed without the `undefined method first_present_value` crash