### PR TITLE
docs: v2.10.0 release notes (native error diagnostics + taxonomy)

### DIFF
--- a/.github/releases/v2.10.0.md
+++ b/.github/releases/v2.10.0.md
@@ -1,0 +1,14 @@
+## Changes
+
+### [#374](https://github.com/velocitycareerlabs/vcl-react-native/pull/374) Align native error handling and bridge diagnostics
+- bridge native iOS/Android `VCLError` diagnostics (native platform, native type, native stack frames, and native cause) across the React Native bridge
+- add a `requestId` and a `diagnostics` object to `VCLError`
+- export the `VCLDiagnostics`, `VCLNativeCauseDiagnostics`, and `VCLErrorInit` types
+- add the `nativeErrorStackFrameLimit` initialization option (default 5, max 20, 0 to disable)
+- pass `errorCodeCompatibilityMode` through to the native SDKs (default `Taxonomy`)
+
+### [#372](https://github.com/velocitycareerlabs/vcl-react-native/pull/372) Update native SDKs
+- wrap the native iOS and Android 2.10.0 SDKs, which implement the unified error taxonomy (issue 3143)
+
+## Backward incompatibilities
+- The wrapped native SDKs now return the new taxonomy error codes by default, with validation-phase and request context on `VCLError`. Set `errorCodeCompatibilityMode` to `Legacy` on `VCLInitializationDescriptor` to preserve the previous error codes.

--- a/.github/releases/v2.10.0.md
+++ b/.github/releases/v2.10.0.md
@@ -1,14 +1,10 @@
 ## Changes
 
-### [#374](https://github.com/velocitycareerlabs/vcl-react-native/pull/374) Align native error handling and bridge diagnostics
-- bridge native iOS/Android `VCLError` diagnostics (native platform, native type, native stack frames, and native cause) across the React Native bridge
-- add a `requestId` and a `diagnostics` object to `VCLError`
-- export the `VCLDiagnostics`, `VCLNativeCauseDiagnostics`, and `VCLErrorInit` types
-- add the `nativeErrorStackFrameLimit` initialization option (default 5, max 20, 0 to disable)
-- pass `errorCodeCompatibilityMode` through to the native SDKs (default `Taxonomy`)
+### Unified error taxonomy — [#372](https://github.com/velocitycareerlabs/vcl-react-native/pull/372), [#374](https://github.com/velocitycareerlabs/vcl-react-native/pull/374)
 
-### [#372](https://github.com/velocitycareerlabs/vcl-react-native/pull/372) Update native SDKs
-- wrap the native iOS and Android 2.10.0 SDKs, which implement the unified error taxonomy (issue 3143)
+- **Error taxonomy**: wrap the native iOS and Android 2.10.0 SDKs, which introduce a unified, cross-platform error taxonomy (issue 3143). Failures now surface as stable, semantic `VCLErrorCode` values shared across iOS, Android, and React Native, replacing platform-specific codes — covering link and connectivity (`invalid_link`, `connectivity_failure`), client request authorization and rejection (`client_request_unauthorized`, `client_request_rejected`), issuer/verifier DID resolution (`issuer_did_unresolvable`, `verifier_did_unresolvable`), registration checks (`registration_check_inconclusive`, `issuer_not_registered`, `verifier_not_registered`), issuer/verifier request validity and authorization (`issuer_request_invalid`, `verifier_request_invalid`, `issuer_request_unauthorized`, `verifier_request_unauthorized`), and a general `sdk_error` fallback.
+- **VCLError diagnostics**: bridge native iOS/Android `VCLError` diagnostics across the React Native bridge — adding `requestId`, a `diagnostics` object (native platform, type, stack frames, and cause), the `nativeErrorStackFrameLimit` (default 5, max 20, 0 to disable) and `errorCodeCompatibilityMode` (default `Taxonomy`) init options, and exporting the `VCLDiagnostics`, `VCLNativeCauseDiagnostics`, and `VCLErrorInit` types.
 
 ## Backward incompatibilities
+
 - The wrapped native SDKs now return the new taxonomy error codes by default, with validation-phase and request context on `VCLError`. Set `errorCodeCompatibilityMode` to `Legacy` on `VCLInitializationDescriptor` to preserve the previous error codes.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@velocitycareerlabs/vcl-react-native",
   "version": "2.10.0",
   "vclNativeSdkVersions": {
-    "ios": "2.10.0-rc",
-    "android": "2.10.0-rc"
+    "ios": "2.10.0",
+    "android": "2.10.0"
   },
   "description": "Velocity Career Labs React Native SDK",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Adds a manual `v2.10.0` release note, mirroring the WalletIOS `.github/releases` convention for cross-SDK parity.

### Highlights
- Native iOS/Android error diagnostics bridged to JS (platform, type, stack frames, cause)
- `requestId` and `diagnostics` on `VCLError`; new exported types `VCLDiagnostics`, `VCLNativeCauseDiagnostics`, `VCLErrorInit`
- `nativeErrorStackFrameLimit` init option (default 5, max 20)
- Wraps native iOS/Android 2.10.0, which implement the unified error taxonomy (issue 3143)

### Backward incompatibilities
- Wrapped native SDKs return taxonomy codes by default; set `errorCodeCompatibilityMode` to `Legacy` to preserve previous codes.

Related: velocity-network-docs SDK v1.28 release notes + SDK Error Taxonomy guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Expanded cross-platform native error diagnostics to include a request identifier and structured diagnostics (native platform/type, stack frames, and native cause).
- Added initialization options to control native error stack frame collection depth (`0` disables; max 20; default 5) and error code compatibility mode (default taxonomy).

**Breaking Changes**
- Default error code behavior now uses the updated cross-platform taxonomy, including validation-phase and request context; use `errorCodeCompatibilityMode: Legacy` to keep prior codes.

**Documentation**
- Updated release notes to reflect the unified error taxonomy behavior and exported diagnostics/error initialization types.

**Chores**
- Bumped iOS and Android native SDK versions to `2.10.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->